### PR TITLE
crossing_detector: Fix Ubuntu detection on non-Ubuntu systems

### DIFF
--- a/crossing_detector/CMakeLists.txt
+++ b/crossing_detector/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(CGAL REQUIRED COMPONENTS Core)
 set(CMAKE_BUILD_TYPE ${OLD_CMAKE_BUILD_TYPE})
 # Manually set CGAL_3RD_PARTY_LIBRARIES on Saucy
 include(cmake/FindUbuntuFlavor.cmake)
-if (${UBUNTU_DIST} EQUAL "13.10")
+if (${UBUNTU_DIST} AND ${UBUNTU_DIST} EQUAL "13.10")
   if (EXISTS "/usr/lib/x86_64-linux-gnu/libboost_thread.so")
     set(CGAL_3RD_PARTY_LIBRARIES "/usr/lib/x86_64-linux-gnu/libboost_thread.so;/usr/lib/x86_64-linux-gnu/libboost_system.so;/usr/lib/x86_64-linux-gnu/libpthread.so" )
   else()


### PR DESCRIPTION
If `UBUNTU_DIST` is unset, the conditional yields an argument error

Example break: https://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-crossing-detector_binaryrpm_heisenbug_x86_64/5/consoleFull

Not yet tested on Ubuntu.
